### PR TITLE
build: add auto-building to Windows binary on commit

### DIFF
--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -1,21 +1,21 @@
 name: Acquire activation file
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
 
 jobs:
   activation:
     name: Request manual activation file 🔑
     runs-on: ubuntu-latest
     steps:
-    - name: Request manual activation file
-      id: getManualLicenseFile
-      uses: webbertakken/unity-request-manual-activation-file@v1.1
-      with:
-        unityVersion: 2019.2.1f1
-    - name: Expose as artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ${{ steps.getManualLicenseFile.outputs.filePath }}
-        path: ${{ steps.getManualLicenseFile.outputs.filePath }}
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: webbertakken/unity-request-manual-activation-file@v1.1
+        with:
+          unityVersion: 2019.2.1f1
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/activate.yml
+++ b/.github/workflows/activate.yml
@@ -1,0 +1,21 @@
+name: Acquire activation file
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+    - name: Request manual activation file
+      id: getManualLicenseFile
+      uses: webbertakken/unity-request-manual-activation-file@v1.1
+      with:
+        unityVersion: 2019.2.1f1
+    - name: Expose as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+        path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/continuous-delivery.yml.yml
+++ b/.github/workflows/continuous-delivery.yml.yml
@@ -1,9 +1,9 @@
 name: Continuous Delivery
 
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/continuous-delivery.yml.yml
+++ b/.github/workflows/continuous-delivery.yml.yml
@@ -25,12 +25,6 @@ jobs:
           path: Assets
           key: ${{ runner.os }}-unity-assets
 
-      # Test
-      - name: Run tests
-        uses: webbertakken/unity-test-runner@v1.3
-        with:
-          unityVersion: 2019.2.1f1
-
       # Build
       - name: Build project
         uses: webbertakken/unity-builder@v0.10

--- a/.github/workflows/continuous-delivery.yml.yml
+++ b/.github/workflows/continuous-delivery.yml.yml
@@ -1,0 +1,45 @@
+name: Continuous Delivery
+
+on:
+    push:
+        branches:
+            - main
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: Assets
+          key: ${{ runner.os }}-unity-assets
+
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.3
+        with:
+          unityVersion: 2019.2.1f1
+
+      # Build
+      - name: Build project
+        uses: webbertakken/unity-builder@v0.10
+        with:
+          unityVersion: 2019.2.1f1
+          targetPlatform: StandaloneWindows64
+
+      # Output
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Build
+          path: build


### PR DESCRIPTION
Once you merge this PR

1. Cancel the continuous delivery job, it will fail first time
2. Wait for activation to be done
3. Download the artifact from it
4. Unzip it to get the `.alf` file
5. Go to <https://license.unity3d.com/manual>
6. Upload the `.alf` file there, select `Unity Personal Edition` then `I don't use Unity in a professional capacity`. Click `Next` then `Download the license file` to get a `.ulf` file.
7. Go the the repo's action secrets 
8. Create a secret named `UNITY_LICENSE` and paste the content of the `.ulf` file in there (open it in a text editor)

These steps are also layed out at <https://unity-ci.com/docs/github/activation>

9. Push again / retrigger CD job